### PR TITLE
Add circToRadius module and tests

### DIFF
--- a/circToRadius.js
+++ b/circToRadius.js
@@ -1,0 +1,10 @@
+function circToRadius(circumference){
+  const radius = (circumference / (2 * Math.PI)) * 0.02;
+  return Math.max(0.1, Math.min(radius, 2.0));
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { circToRadius };
+} else {
+  window.circToRadius = circToRadius;
+}

--- a/index.html
+++ b/index.html
@@ -155,9 +155,10 @@
   </section>
 </main>
 
-<div class="footer">MIT License • Built for privacy & control</div>
+  <div class="footer">MIT License • Built for privacy & control</div>
 
-<script>
+  <script src="./circToRadius.js"></script>
+  <script>
 /*** ---------- Simple Local Data Model ---------- ***/
 const HEADERS = ["Date","Weight","Neck","Chest","Waist","Hips","BicepL","BicepR","ThighL","ThighR","BodyFat","Notes"];
 let DATA = [];              // Array of rows (objects)
@@ -398,12 +399,7 @@ function init3D(){
   }
   animate();
 }
-function circToRadius(circumference){
-  // Scale centimeters to scene units (roughly): radius = (circ / 2π) * scale
-  const radius = (circumference / (2 * Math.PI)) * 0.02; // 0.02 ~ scene scale factor
-  return Math.max(0.1, Math.min(radius, 2.0));
-}
-function update3DRings(){
+  function update3DRings(){
   if(!DATA.length || !rings.chest) return;
   const last = DATA[DATA.length-1];
   if(last.Chest) rings.chest.geometry = new THREE.TorusGeometry(circToRadius(last.Chest), 0.03, 12, 64);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "body-tracker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "circToRadius.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "MIT"
+}

--- a/tests/circToRadius.test.js
+++ b/tests/circToRadius.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { circToRadius } = require('../circToRadius');
+
+test('Values below the minimum return 0.1', () => {
+  assert.strictEqual(circToRadius(0), 0.1);
+  assert.strictEqual(circToRadius(-50), 0.1);
+});
+
+test('Values above the maximum return 2.0', () => {
+  assert.strictEqual(circToRadius(10000), 2.0);
+});
+
+test('Mid-range values are scaled correctly', () => {
+  const circumference = 100; // cm
+  const expected = (circumference / (2 * Math.PI)) * 0.02;
+  assert.strictEqual(circToRadius(circumference), expected);
+});


### PR DESCRIPTION
## Summary
- extract `circToRadius` into its own module for reuse in browser and Node
- load `circToRadius` module in the app
- add unit tests for `circToRadius` and npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a065aefb048323bbfb49262a189df5